### PR TITLE
Add bottom tagline to About page

### DIFF
--- a/src/pages/About.vue
+++ b/src/pages/About.vue
@@ -28,6 +28,9 @@
         </p>
       </div>
     </div>
+    <div class="about-bottom-tagline">
+      WE SIT AT<br />THE CENTER<br />OF CULTURE
+    </div>
   </div>
 </template>
 
@@ -166,6 +169,24 @@ onMounted(() => {
   font-family: 'Soehne', sans-serif;
   font-weight: 500;
   text-align: left;
+}
+
+.about-bottom-tagline {
+  font-size: 6.25rem;
+  text-align: center;
+  text-transform: uppercase;
+  font-family: 'Rework Display Regular', sans-serif;
+  font-weight: 600;
+  color: #111;
+  line-height: 0.9;
+  letter-spacing: 0.125rem;
+  margin-bottom: 8rem;
+}
+
+@media (max-width: 768px) {
+  .about-bottom-tagline {
+    font-size: 2.5rem;
+  }
 }
 
 @media (max-width: 768px) {


### PR DESCRIPTION
## Summary
- update About.vue with a new bottom tagline
- style the tagline so it centers on the page

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686eb6223150832eb0da0629bc831ec3